### PR TITLE
SDK support for OAuth2 password grants and tokens:

### DIFF
--- a/app/com/galacticfog/gestalt/security/api/GestaltToken.scala
+++ b/app/com/galacticfog/gestalt/security/api/GestaltToken.scala
@@ -1,0 +1,55 @@
+package com.galacticfog.gestalt.security.api
+
+import java.util.UUID
+
+trait GestaltToken extends GestaltResource {
+  import GestaltToken._
+
+  def tokenType: GestaltToken.TokenType
+  override def href: String = tokenType match {
+    case ACCESS_TOKEN => s"/accessTokens/${id}"
+  }
+  override def name: String = tokenType match {
+    case ACCESS_TOKEN => s"accessToken-${id}"
+  }
+}
+
+object GestaltToken {
+  sealed trait TokenType
+  final case object ACCESS_TOKEN extends TokenType
+}
+
+case class OpaqueToken(override val id: UUID, override val tokenType: GestaltToken.TokenType) extends GestaltToken {
+  override def toString: String = id.toString
+}
+
+case class AccessTokenResponse(accessToken: GestaltToken,
+                               refreshToken: Option[GestaltToken],
+                               tokenType: AccessTokenResponse.TokenType,
+                               expiresIn: Long,
+                               gestalt_access_token_href: String)
+
+case object AccessTokenResponse {
+  sealed trait TokenType
+  final case object BEARER  extends TokenType {override def toString() = "bearer"}
+}
+
+sealed trait TokenIntrospectionResponse {
+  def active: Boolean
+}
+
+final case class ValidTokenResponse(
+  username: String,
+  sub: String,
+  iss: String,
+  exp: Long,
+  iat: Long,
+  jti: UUID,
+  gestalt_token_href: String,
+  gestalt_rights: Seq[GestaltRightGrant]) extends TokenIntrospectionResponse {
+  override val active: Boolean = true
+}
+
+final case object INVALID_TOKEN extends TokenIntrospectionResponse {
+  override val active: Boolean = false
+}

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,9 @@ libraryDependencies ++= Seq(
 // MockWS for testing
 libraryDependencies += "de.leanovate.play-mockws" %% "play-mockws" % "2.3.0" % "test" withSources()
 
+// jjwt for JSON Web Tokens
+//libraryDependencies += "io.jsonwebtoken" % "jjwt" % "0.6.0" withSources()
+
 
 // ----------------------------------------------------------------------------
 // Specs 2


### PR DESCRIPTION
- added oauth/issue and oauth/inspect endpoints for token generation and introspection per oauth2 standard
